### PR TITLE
Using cross-spawn to fix PATHEXT misery on Windows

### DIFF
--- a/lib/installers/bower.js
+++ b/lib/installers/bower.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn-async');
 var path = require('path');
 var Promise = require('bluebird');
 

--- a/lib/installers/npm.js
+++ b/lib/installers/npm.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn-async');
 var Promise = require('bluebird');
 
 module.exports = function (log) {

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -1,4 +1,4 @@
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn-async');
 var path = require('path');
 
 var Promise = require('bluebird');

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bower": "1.4.1",
     "bunyan": "0.22.3",
     "convict": "0.4.2",
+    "cross-spawn-async": "^2.1.6",
     "express": "3.17.4",
     "filesize": "2.0.3",
     "freight": "0.5.2",


### PR DESCRIPTION
Spawning `npm` or `bower` will fail on Windows because of [this issue](https://github.com/nodejs/node-v0.x-archive/issues/2318). The easiest workaround is to use `win-spawn`, which also works on other platforms.