### PR TITLE
Created 'inprogress' file name whilst compressing bundle

### DIFF
--- a/lib/job_processor.js
+++ b/lib/job_processor.js
@@ -108,7 +108,7 @@ module.exports = function (log) {
       log.info('Compressing project:', project.name);
       var start = Date.now();
 
-      var progress_filepath = path.replace('.tar.gz','_inprogress.tar.gz');
+      var progressFilepath = path.replace('.tar.gz', '_inprogress.tar.gz');
       var output = fs.createWriteStream(path);
       var archive = archiver('tar', {
         gzip: true,
@@ -118,7 +118,7 @@ module.exports = function (log) {
       });
 
       output.on('close', function () {
-        fs.rename(progress_filepath, path);
+        fs.rename(progressFilepath, path);
         var end = Date.now();
         log.info('Bundle created:', path);
         log.info('Compression completed in ', (end - start) / 1000, 'seconds.', archive.pointer() + ' total bytes');

--- a/lib/job_processor.js
+++ b/lib/job_processor.js
@@ -108,6 +108,7 @@ module.exports = function (log) {
       log.info('Compressing project:', project.name);
       var start = Date.now();
 
+      var progress_filepath = path.replace('.tar.gz','_inprogress.tar.gz');
       var output = fs.createWriteStream(path);
       var archive = archiver('tar', {
         gzip: true,
@@ -117,6 +118,7 @@ module.exports = function (log) {
       });
 
       output.on('close', function () {
+        fs.rename(progress_filepath, path);
         var end = Date.now();
         log.info('Bundle created:', path);
         log.info('Compression completed in ', (end - start) / 1000, 'seconds.', archive.pointer() + ' total bytes');


### PR DESCRIPTION
I found that from time to time, when using the freight client, if you called freight whilst the bundle archive was in the process of compressing, the bundle would still download but it would be truncated and corrupted. So a little fix went in to temporarily name the archive during compression, and rename it back after the compression was done. Seems to have fixed our issues.